### PR TITLE
Refactor Dashboard Scrolling

### DIFF
--- a/src/components/CourseCard.tsx
+++ b/src/components/CourseCard.tsx
@@ -2,12 +2,35 @@ import { Card, Group, Text } from "@mantine/core";
 import Chip from "@/components/ChipFilled";
 import { stringToColor, stringToDeg } from "@/lib/color";
 import { CardWrapper } from "@/types/courseCard";
+import { useScrollHandler } from "@/lib/placement";
+import { useCallback } from "react";
+import { Node, useNodeId, useReactFlow } from "@xyflow/react";
 
 export default function CourseCard({ data }: CardWrapper) {
     const { courseCode, courseName, faculty, chips } = data;
+    const { getNode, getIntersectingNodes } = useReactFlow();
+    const node_id = useNodeId() as string; // we are sure this is a string
+    const { scrollHandler } = useScrollHandler();
+
+    // only support wheel scrolling for cards since touchmove  is used for dragging cards
+    const onWheel = useCallback(
+        (event: React.WheelEvent) => {
+            const self = getNode(node_id) as Node; // we know for sure this node exists
+            const intersectingNodes = getIntersectingNodes(self);
+
+            // should always be intersecting nodes because card will always be on semester
+            // first (and only) on will be the semester
+            if (intersectingNodes.length == 1) {
+                const deltaY = event.deltaY;
+                scrollHandler(intersectingNodes[0], deltaY);
+            }
+        },
+        [scrollHandler, getIntersectingNodes, getNode, node_id]
+    );
+
     return (
         <Card
-            className="h-44 w-80 select-none not-prose"
+            className="h-44 w-80 select-none not-prose nowheel"
             radius="lg"
             shadow="sm"
             padding="lg"
@@ -19,6 +42,7 @@ export default function CourseCard({ data }: CardWrapper) {
                     courseName
                 )})`,
             }}
+            onWheel={onWheel}
         >
             <Text
                 className="leading-none"

--- a/src/components/semester/Semester.tsx
+++ b/src/components/semester/Semester.tsx
@@ -1,68 +1,49 @@
 import { SemesterWrapper } from "@/types/semester";
 import { Paper } from "@mantine/core";
-import { applyNodeChanges, Node, useNodeId, useReactFlow } from "@xyflow/react";
+import { Node, useNodeId, useReactFlow } from "@xyflow/react";
 import { useCallback, useState } from "react";
 import SemesterData from "@/components/semester/SemesterData";
+import { useScrollHandler } from "@/lib/placement";
 
 // remember that touchevents coordinates and mouse coordinates aren't exactly the same...
 
 export default function Semester({ data }: SemesterWrapper) {
-    const { getIntersectingNodes, setNodes, getNode } = useReactFlow();
+    const { getNode } = useReactFlow();
     const node_id = useNodeId() as string; // we are sure this is a string
     const [lastY, setLastY] = useState(0);
+    const { scrollHandler } = useScrollHandler();
 
-    const handleDeltaY = useCallback(
-        (deltaY: number) => {
-            const id = { id: node_id };
-
-            // remember that variables defined outside are not updated (self on outside means position stays the same)
-            const self = getNode(node_id) as Node; // we are sure this is a node
-            const nodesToMove = getIntersectingNodes(id);
-            nodesToMove.push(self);
-            const newPositions = nodesToMove.map((node) => {
-                const { x, y } = node.position;
-                const newPosition = { x: x, y: y + deltaY };
-                return {
-                    id: node.id,
-                    type: "position" as const,
-                    position: newPosition,
-                    dragging: false,
-                };
-            });
-            setNodes((nds) => applyNodeChanges(newPositions, nds));
-        },
-        [getIntersectingNodes, getNode, node_id, setNodes]
-    );
-
-    const handleScroll = useCallback(
+    const onWheel = useCallback(
         (event: React.WheelEvent) => {
+            const self = getNode(node_id) as Node; // we know for sure this node exists
             const deltaY = event.deltaY;
-            handleDeltaY(deltaY);
+            scrollHandler(self, deltaY);
         },
-        [handleDeltaY]
+        [scrollHandler, getNode, node_id]
     );
 
     // usecallback depends on lastY, only call it if lastY changes
-    const handleMove = useCallback(
+    const onTouchMove = useCallback(
         (event: React.TouchEvent) => {
+            const self = getNode(node_id) as Node; // we know for sure this node exists
             const currentY = event.changedTouches[0].pageY;
             const deltaY = currentY - lastY;
-            handleDeltaY(deltaY);
+            scrollHandler(self, deltaY);
             setLastY(currentY);
         },
-        [lastY, handleDeltaY]
+        [lastY, scrollHandler, getNode, node_id]
     );
 
-    const handleFirstTouch = useCallback((event: React.TouchEvent) => {
+    const onTouchStart = useCallback((event: React.TouchEvent) => {
         setLastY(event.changedTouches[0].pageY);
     }, []);
 
     return (
         <Paper
             className="nowheel nodrag flex justify-center items-start"
-            onWheel={handleScroll}
-            onTouchMove={handleMove}
-            onTouchStart={handleFirstTouch}
+            onWheel={onWheel}
+            onTouchMove={onTouchMove}
+            onTouchStart={onTouchStart}
             radius={10}
             style={{
                 height: "500px",

--- a/src/lib/placement.ts
+++ b/src/lib/placement.ts
@@ -1,0 +1,30 @@
+import { useCallback } from "react";
+import { applyNodeChanges, Node, useReactFlow } from "@xyflow/react";
+
+// function takes in a node and moves all nodes connected to it
+export const useScrollHandler = () => {
+    const { getIntersectingNodes, setNodes } = useReactFlow();
+
+    const scrollHandler = useCallback(
+        (targetNode: Node, distance: number) => {
+            const nodesToMove = getIntersectingNodes(targetNode);
+            nodesToMove.push(targetNode);
+
+            const newPositions = nodesToMove.map((currentNode: Node) => {
+                const { x, y } = currentNode.position;
+                const newPosition = { x: x, y: y + distance };
+                return {
+                    id: currentNode.id,
+                    type: "position" as const,
+                    position: newPosition,
+                    dragging: false,
+                };
+            });
+
+            setNodes((nodes) => applyNodeChanges(newPositions, nodes));
+        },
+        [getIntersectingNodes, setNodes]
+    );
+
+    return { scrollHandler };
+};


### PR DESCRIPTION
This PR aims to address the issues with the dashboard scrolling function. The changes are as follows:

1. The function has been abstracted away into a hook, and can be called from multiple places now
2. The card now supports scrolling with the mouse wheel only (mouse move is used for moving cards)

TODO: Limit how far the cards can scroll