### PR TITLE
Add prerequisite checking for course cards

### DIFF
--- a/src/app/(main)/dashboard/courses/DashboardComponent.tsx
+++ b/src/app/(main)/dashboard/courses/DashboardComponent.tsx
@@ -182,7 +182,7 @@ export default function DashboardComponent({
                             courseInformation: course.data,
                             courseToSemesters: () => relatedSemesterId,
                             selectSemester: selectSemester,
-                            prerequisiteMet: false,
+                            prerequisiteMet: undefined,
                         },
                         type: "courseDropdownNode",
                         position: { x: 0, y: 0 },

--- a/src/app/(main)/dashboard/courses/DashboardComponent.tsx
+++ b/src/app/(main)/dashboard/courses/DashboardComponent.tsx
@@ -17,6 +17,7 @@ import {
     placeWrappers,
     PrerequisiteNodeType,
     Wrapper,
+    useCheckPrerequisites,
 } from "@/lib/tree";
 import CourseSearch from "@/components/courseSearch/CourseSearch";
 import { DnDContext } from "@/components/dndContext";
@@ -30,6 +31,8 @@ import { CourseSemesterContext } from "@/app/(main)/dashboard/courses/courseSeme
 import AndWrapper from "@/components/wrapper/AndWrapper";
 import OrWrapper from "@/components/wrapper/OrWrapper";
 import eventBus from "@/lib/eventBus";
+import { NodeContext } from "@/app/(main)/dashboard/courses/nodeContext";
+import { SemesterContext } from "@/app/(main)/dashboard/courses/semesterContext";
 
 const nodeTypes = {
     prerequisiteDropdownNode: CourseCardPostrequisiteDropdownWrapper,
@@ -47,13 +50,16 @@ export default function DashboardComponent({
     postrequisites: { [key: string]: number[] };
     courseIds: { [courseCode: string]: number };
 }) {
-    const [nextPostrequisites, setNextPostrequisites] = useState<
-        DropdownCardWrapper[]
-    >([]);
-    const [nodes, setNodes] = useState<Node[]>([]);
     const [edges, setEdges] = useState<Edge[]>([]);
     const [height, setHeight] = useState(1);
     const { fitView } = useReactFlow();
+    const { checkPrerequisites } = useCheckPrerequisites();
+
+    const nodeContextItem = useContext(NodeContext);
+    if (!nodeContextItem) {
+        throw new Error("DashboardComponent must be used in a NodeContext");
+    }
+    const [nodes, setNodes] = nodeContextItem;
 
     const courseSemesterContextItem = useContext(CourseSemesterContext);
     if (!courseSemesterContextItem) {
@@ -62,6 +68,12 @@ export default function DashboardComponent({
         );
     }
     const [relatedSemesterId, setRelatedSemesterId] = courseSemesterContextItem;
+
+    const semesterDictContextItem = useContext(SemesterContext);
+    if (!semesterDictContextItem) {
+        throw new Error("CourseCardForm must be used in a SemesterContext");
+    }
+    const [semesterDict] = semesterDictContextItem;
 
     const dndContextItem = useContext(DnDContext);
     if (!dndContextItem) {
@@ -170,6 +182,7 @@ export default function DashboardComponent({
                             courseInformation: course.data,
                             courseToSemesters: () => relatedSemesterId,
                             selectSemester: selectSemester,
+                            prerequisiteMet: false,
                         },
                         type: "courseDropdownNode",
                         position: { x: 0, y: 0 },
@@ -188,18 +201,54 @@ export default function DashboardComponent({
                                     courseInformation[postrequisiteId],
                                 courseToSemesters: () => relatedSemesterId,
                                 selectSemester: selectSemester,
+                                prerequisiteMet: false,
                             },
                             type: "prerequisiteDropdownNode",
                             postition: { x: 0, y: 0 },
                         };
                     });
 
-                setNextPostrequisites(postrequisiteDropdownCourses);
-
                 setNodes(dropdownCourses as Node[]);
                 setEdges(edgeOutput);
-            };
 
+                const fitAndPlaceEdges = async () => {
+                    fitView({ padding: 0.1 });
+
+                    // Small delay to allow layout adjustments if needed
+                    await new Promise((resolve) => setTimeout(resolve, 500));
+
+                    let newEdges: Edge[];
+                    setNodes((currentNodes) => {
+                        if (currentNodes.length > 0) {
+                            const updatedNodes = [...currentNodes];
+                            const temp = getPostrequisitePlacements(
+                                updatedNodes,
+                                postrequisiteDropdownCourses
+                            );
+                            newEdges = temp["newEdges"];
+                            const newNodes = temp["newNodes"];
+
+                            return updatedNodes.concat(newNodes);
+                        }
+                        return currentNodes;
+                    });
+                    setEdges((currentEdges) => {
+                        if (newEdges && newEdges.length > 0) {
+                            return currentEdges.concat(newEdges);
+                        }
+                        return currentEdges;
+                    });
+
+                    setTimeout(
+                        () =>
+                            checkPrerequisites(relatedSemesterId, semesterDict),
+                        100
+                    );
+                };
+
+                // let React update the nodes before centering page
+                setTimeout(fitAndPlaceEdges, 100);
+            };
             handler();
         },
         [
@@ -210,6 +259,10 @@ export default function DashboardComponent({
             relatedSemesterId,
             setRelatedSemesterId,
             courseIds,
+            setNodes,
+            checkPrerequisites,
+            fitView,
+            semesterDict,
         ]
     );
 
@@ -231,38 +284,16 @@ export default function DashboardComponent({
         }
     }, []);
 
-    useEffect(() => {
-        const fitAndPlaceEdges = async () => {
-            fitView({ padding: 0.1 });
+    // useEffect(() => {
 
-            // Small delay to allow layout adjustments if needed
-            await new Promise((resolve) => setTimeout(resolve, 500));
-
-            let newEdges: Edge[];
-            setNodes((currentNodes) => {
-                if (currentNodes.length > 0) {
-                    const updatedNodes = [...currentNodes];
-                    const temp = getPostrequisitePlacements(
-                        updatedNodes,
-                        nextPostrequisites
-                    );
-                    newEdges = temp["newEdges"];
-                    const newNodes = temp["newNodes"];
-
-                    return updatedNodes.concat(newNodes);
-                }
-                return currentNodes;
-            });
-            setEdges((currentEdges) => {
-                if (newEdges && newEdges.length > 0) {
-                    return currentEdges.concat(newEdges);
-                }
-                return currentEdges;
-            });
-        };
-
-        setTimeout(fitAndPlaceEdges, 10);
-    }, [fitView, nextPostrequisites]);
+    // }, [
+    //     fitView,
+    //     nextPostrequisites,
+    //     checkPrerequisites,
+    //     relatedSemesterId,
+    //     semesterDict,
+    //     setNodes,
+    // ]);
 
     const closeDropdowns = useCallback(() => {
         eventBus.dispatchEvent(new CustomEvent("closeDropdowns", {}));

--- a/src/app/(main)/dashboard/courses/DashboardWrapper.tsx
+++ b/src/app/(main)/dashboard/courses/DashboardWrapper.tsx
@@ -15,6 +15,8 @@ import { SemesterDict, SemesterTerm } from "@/types/semester";
 import { SemesterContext } from "@/app/(main)/dashboard/courses/semesterContext";
 import { Session } from "next-auth";
 import { SessionContext } from "@/components/sessionContext";
+import { NodeContext } from "./nodeContext";
+import { Node } from "@xyflow/react";
 
 export default function DashboardWrapper({
     session,
@@ -29,6 +31,7 @@ export default function DashboardWrapper({
     allSemesters: SemesterDict;
     courseIds: { [courseCode: string]: number };
 }) {
+    const [nodes, setNodes] = useState<Node[]>([]);
     const [type, setType] = useState<[string, CourseInformation] | null>(null);
     const [relatedSemesterId, setRelatedSemesterId] =
         useState<CourseToSemesterIdDict>({});
@@ -53,11 +56,13 @@ export default function DashboardWrapper({
                 >
                     <SemesterFormProvider form={form}>
                         <DnDContext.Provider value={[type, setType]}>
-                            <DashboardComponent
-                                prerequisites={prerequisites}
-                                postrequisites={postrequisites}
-                                courseIds={courseIds}
-                            />
+                            <NodeContext.Provider value={[nodes, setNodes]}>
+                                <DashboardComponent
+                                    prerequisites={prerequisites}
+                                    postrequisites={postrequisites}
+                                    courseIds={courseIds}
+                                />
+                            </NodeContext.Provider>
                         </DnDContext.Provider>
                     </SemesterFormProvider>
                 </CourseSemesterContext.Provider>

--- a/src/app/(main)/dashboard/courses/nodeContext.ts
+++ b/src/app/(main)/dashboard/courses/nodeContext.ts
@@ -1,0 +1,5 @@
+import { createContext } from "react";
+
+import { NodeContextType } from "@/types/courseCard";
+
+export const NodeContext = createContext<NodeContextType | null>(null);

--- a/src/components/courseCard/CourseCard.css
+++ b/src/components/courseCard/CourseCard.css
@@ -7,6 +7,16 @@
 }
 
 :root[data-mantine-color-scheme="dark"]
+    .course-error.mantine-Paper-root.card-dropdown {
+    background-color: #be6161 !important;
+}
+
+:root[data-mantine-color-scheme="light"]
+    .course-error.mantine-Paper-root.card-dropdown {
+    background-color: #ef8080 !important;
+}
+
+:root[data-mantine-color-scheme="dark"]
     .course-included.mantine-Paper-root.card-dropdown {
     background-color: #61be61 !important;
 }

--- a/src/components/courseCard/CourseCard.css
+++ b/src/components/courseCard/CourseCard.css
@@ -1,3 +1,41 @@
 .course-card.mantine-Paper-root {
     background-color: #22242e !important;
 }
+
+.mantine-Paper-root.card-dropdown {
+    transition: background-color 400ms ease-in-out;
+}
+
+:root[data-mantine-color-scheme="dark"]
+    .course-included.mantine-Paper-root.card-dropdown {
+    background-color: #61be61 !important;
+}
+
+:root[data-mantine-color-scheme="light"]
+    .course-included.mantine-Paper-root.card-dropdown {
+    background-color: #80ef80 !important;
+}
+
+:root[data-mantine-color-scheme="dark"]
+    .course-prerequisite-met.mantine-Paper-root.card-dropdown {
+    background-color: #a2be61 !important;
+}
+
+:root[data-mantine-color-scheme="light"]
+    .course-prerequisite-met.mantine-Paper-root.card-dropdown {
+    background-color: #dbef80 !important;
+}
+
+:root[data-mantine-color-scheme="light"] .mantine-InputBase-input {
+    background-color: #7a7a7abf !important;
+    color: white;
+}
+
+:root[data-mantine-color-scheme="dark"] .mantine-InputBase-input {
+    background-color: #2c2a31bf !important;
+    color: white;
+}
+
+:root[data-mantine-color-scheme="light"] .mantine-InputPlaceholder-placeholder {
+    color: rgb(226, 226, 226);
+}

--- a/src/components/courseCard/CourseCard.tsx
+++ b/src/components/courseCard/CourseCard.tsx
@@ -59,11 +59,15 @@ export function CourseCardDropdownWrapper({
 }: {
     data: CourseDropdownInformation;
 }) {
-    const { courseInformation, selectSemester } = data;
-
+    const { courseInformation, selectSemester, prerequisiteMet } = data;
+    const addedClass = prerequisiteMet
+        ? prerequisiteMet === true
+            ? "course-included"
+            : "course-prerequisite-met"
+        : "";
     return (
         <Card
-            className="h-64 flex content-between justify-between"
+            className={`h-64 flex content-between justify-between card-dropdown ${addedClass}`}
             radius="lg"
             shadow="sm"
         >

--- a/src/components/courseCard/CourseCard.tsx
+++ b/src/components/courseCard/CourseCard.tsx
@@ -64,6 +64,8 @@ export function CourseCardDropdownWrapper({
         ? prerequisiteMet === true
             ? "course-included"
             : "course-prerequisite-met"
+        : prerequisiteMet === false
+        ? "course-error"
         : "";
     return (
         <Card

--- a/src/components/courseCard/CourseCardForm.tsx
+++ b/src/components/courseCard/CourseCardForm.tsx
@@ -1,6 +1,7 @@
 import { CourseSemesterContext } from "@/app/(main)/dashboard/courses/courseSemesterContext";
 import { SemesterContext } from "@/app/(main)/dashboard/courses/semesterContext";
 import eventBus from "@/lib/eventBus";
+import { useCheckPrerequisites } from "@/lib/tree";
 import { SemesterInformation, termOrder } from "@/types/semester";
 import {
     CloseButton,
@@ -39,6 +40,7 @@ export default function CourseCardForm({
 
     const combobox = useCombobox();
     const comboboxRef = useRef(combobox);
+    const { checkPrerequisites } = useCheckPrerequisites();
     const options: ReactNode[] = [];
     let orderedSemesters: SemesterInformation[] = [];
     const selection = relatedSemesterId[courseCode];
@@ -110,6 +112,12 @@ export default function CourseCardForm({
 
                 selectSemester(courseCode, semesterId);
                 combobox.closeDropdown();
+                if (semesterId) {
+                    relatedSemesterId[courseCode] = semesterId;
+                } else {
+                    delete relatedSemesterId[courseCode];
+                }
+                checkPrerequisites(relatedSemesterId, semesterDict);
             }}
         >
             <Combobox.Target>
@@ -138,6 +146,12 @@ export default function CourseCardForm({
                                             method: "DELETE",
                                         }
                                     );
+                                    delete relatedSemesterId[courseCode];
+
+                                    checkPrerequisites(
+                                        relatedSemesterId,
+                                        semesterDict
+                                    );
                                 }}
                                 aria-label="Clear value"
                             />
@@ -145,6 +159,7 @@ export default function CourseCardForm({
                             <Combobox.Chevron />
                         )
                     }
+                    c="white"
                 >
                     {selection ? (
                         `${semesterDict[selection].semesterYear.getFullYear()}${

--- a/src/lib/tree.ts
+++ b/src/lib/tree.ts
@@ -1,5 +1,16 @@
-import { DropdownCardWrapper, WrapperWrapper } from "@/types/courseCard";
+import { NodeContext } from "@/app/(main)/dashboard/courses/nodeContext";
+import {
+    CourseToSemesterIdDict,
+    DropdownCardWrapper,
+    WrapperWrapper,
+} from "@/types/courseCard";
+import {
+    SemesterDict,
+    SemesterInformation,
+    SemesterTerm,
+} from "@/types/semester";
 import { Edge, Node } from "@xyflow/react";
+import { useCallback, useContext, useEffect, useRef } from "react";
 
 export interface PrerequisiteNodeType {
     courseName: string;
@@ -302,6 +313,9 @@ export function placeWrappers(
                 width: width,
                 height: height,
             },
+            data: {
+                prerequisiteMet: false,
+            },
         };
         nodes.push(wrapperNode);
     }
@@ -358,10 +372,6 @@ function placeManyPostrequisites(
             style: {
                 strokeWidth: 3,
                 opacity: 0.25,
-                animation: "fadein 0.5s",
-                WebkitAnimation: "fadein 0.5s", // Safari, Chrome
-                MozAnimation: "fadein 0.5s", // Firefox
-                OAnimation: "fadein 0.5s", // Opera
             },
             source: firstNode.id,
             target: id,
@@ -571,4 +581,144 @@ function handleRequirements(
             }
         }
     }
+}
+
+export function useCheckPrerequisites() {
+    const nodeContextItem = useContext(NodeContext);
+    if (!nodeContextItem) {
+        throw new Error("DashboardComponent must be used in a NodeContext");
+    }
+    const [nodes, setNodes] = nodeContextItem;
+    const nodesRef = useRef(nodes);
+
+    useEffect(() => {
+        nodesRef.current = nodes;
+    }, [nodes]);
+
+    const checkPrerequisites = useCallback(
+        (
+            courseCodeToSemester: CourseToSemesterIdDict,
+            allSemesters: SemesterDict
+        ) => {
+            let nodes = nodesRef.current;
+            nodes = nodes.sort(sortNodePrerequisites);
+
+            const seenCourses: { [courseCode: string]: Date } = {};
+
+            nodes.forEach((node) => {
+                node.data.prerequisiteMet = false;
+            });
+
+            nodes.forEach((node) => {
+                if (
+                    node.type === "andWrapperNode" ||
+                    node.type === "orWrapperNode"
+                ) {
+                } else {
+                    const cardNode = node as unknown as DropdownCardWrapper;
+                    const courseData = cardNode.data.courseInformation;
+                    const prerequisites = courseData.prerequisites;
+
+                    let relatedDate: Date;
+                    const relatedSemesterId =
+                        courseCodeToSemester[courseData.courseCode];
+                    if (relatedSemesterId === undefined) {
+                        relatedDate = new Date(2100, 0, 1);
+                    } else {
+                        const relatedSemester = allSemesters[relatedSemesterId];
+                        relatedDate = generateRelatedDate(relatedSemester);
+                    }
+
+                    if (prerequisites.length === 0 && relatedSemesterId) {
+                        cardNode.data.prerequisiteMet = true;
+                        seenCourses[courseData.courseCode] = relatedDate;
+                        return;
+                    } else if (prerequisites.length === 0) {
+                        cardNode.data.prerequisiteMet = "partially";
+                        return;
+                    }
+
+                    const prerequisite_eval = prerequisites.replace(
+                        /{([\w\s]+)}/g,
+                        (_, prerequisite) => {
+                            const prerequisiteCheck = courseTakenAlready(
+                                prerequisite,
+                                seenCourses,
+                                relatedDate
+                            );
+                            return prerequisiteCheck.toString();
+                        }
+                    );
+                    const prerequisiteMet = eval(prerequisite_eval);
+
+                    if (prerequisiteMet && relatedSemesterId) {
+                        seenCourses[courseData.courseCode] = relatedDate;
+                        cardNode.data.prerequisiteMet = prerequisiteMet;
+                    } else if (prerequisiteMet) {
+                        cardNode.data.prerequisiteMet = "partially";
+                    }
+                }
+            });
+            const newNodes = nodes.map((node) => {
+                return { ...node };
+            });
+
+            setNodes(newNodes);
+        },
+        [setNodes]
+    );
+
+    return { checkPrerequisites };
+}
+
+function sortNodePrerequisites(a: Node, b: Node): number {
+    const aFirst = checkOneIsWrapper(a, b);
+    if (aFirst) return aFirst;
+    const bFirst = checkOneIsWrapper(b, a);
+    if (bFirst) return -bFirst;
+
+    return a.position.x - b.position.x;
+}
+
+function checkOneIsWrapper(a: Node, b: Node): number | undefined {
+    if (a.type === "orWrapperNode" || a.type === "andWrapperNode") {
+        if (b.type !== "orWrapperNode" && b.type !== "andWrapperNode") {
+            return 1;
+        }
+        return b.id.split("-").length - a.id.split("-").length;
+    }
+}
+
+function generateRelatedDate(semester: SemesterInformation) {
+    let monthIndex: number;
+
+    switch (semester.semesterTerm) {
+        case SemesterTerm.WI:
+            monthIndex = 1;
+            break;
+        case SemesterTerm.SP:
+            monthIndex = 5;
+            break;
+        case SemesterTerm.SU:
+            monthIndex = 7;
+            break;
+        case SemesterTerm.FA:
+            monthIndex = 9;
+            break;
+    }
+    return new Date(semester.semesterYear.getFullYear(), monthIndex);
+}
+
+function courseTakenAlready(
+    courseToCheck: string,
+    seenCourses: { [courseCode: string]: Date },
+    deadlineDate: Date
+): boolean {
+    const originalCourseDate = seenCourses[courseToCheck];
+
+    if (!originalCourseDate) {
+        return false;
+    }
+
+    return originalCourseDate < deadlineDate;
 }

--- a/src/lib/tree.ts
+++ b/src/lib/tree.ts
@@ -606,7 +606,7 @@ export function useCheckPrerequisites() {
             const seenCourses: { [courseCode: string]: Date } = {};
 
             nodes.forEach((node) => {
-                node.data.prerequisiteMet = false;
+                node.data.prerequisiteMet = undefined;
             });
 
             nodes.forEach((node) => {
@@ -656,6 +656,8 @@ export function useCheckPrerequisites() {
                         cardNode.data.prerequisiteMet = prerequisiteMet;
                     } else if (prerequisiteMet) {
                         cardNode.data.prerequisiteMet = "partially";
+                    } else if (!prerequisiteMet && relatedSemesterId) {
+                        cardNode.data.prerequisiteMet = false;
                     }
                 }
             });

--- a/src/types/courseCard.ts
+++ b/src/types/courseCard.ts
@@ -50,7 +50,7 @@ export interface CourseDropdownInformation {
         courseCode: string,
         semesterId: number | undefined
     ) => void;
-    prerequisiteMet: false | true | "partially";
+    prerequisiteMet: false | true | "partially" | undefined;
 }
 
 export interface CourseInformation {

--- a/src/types/courseCard.ts
+++ b/src/types/courseCard.ts
@@ -1,4 +1,4 @@
-import { XYPosition } from "@xyflow/react";
+import { Node, XYPosition } from "@xyflow/react";
 import { ChipVariant } from "@/types/chipVariant";
 
 export interface CardWrapper {
@@ -18,6 +18,11 @@ export type CourseCodeToSemester = [
     React.Dispatch<React.SetStateAction<CourseToSemesterIdDict>>
 ];
 
+export type NodeContextType = [
+    Node[],
+    React.Dispatch<React.SetStateAction<Node[]>>
+];
+
 export interface DropdownCardWrapper {
     type?: string;
     id?: string;
@@ -34,6 +39,9 @@ export interface WrapperWrapper {
     position?: XYPosition;
     measured?: { width: number; height: number };
     style?: React.CSSProperties;
+    data: {
+        prerequisiteMet: boolean;
+    };
 }
 
 export interface CourseDropdownInformation {
@@ -42,6 +50,7 @@ export interface CourseDropdownInformation {
         courseCode: string,
         semesterId: number | undefined
     ) => void;
+    prerequisiteMet: false | true | "partially";
 }
 
 export interface CourseInformation {


### PR DESCRIPTION
This PR adds indicators for which courses can be taken in the course overview page.

1. Courses that are not touched are the original color
2. Courses that can be taken, but are not, are yellow
3. Courses that are taken, but don't have their prerequisites met, are red
4. Courses that are taken and have their prerequisites met are green